### PR TITLE
Workflow CT: Fixing Node version 16 in yaml

### DIFF
--- a/.github/workflows/continuous_training.yaml
+++ b/.github/workflows/continuous_training.yaml
@@ -17,10 +17,14 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Set up Node 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16'
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Train model
         env:
@@ -53,4 +57,5 @@ jobs:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat report.txt >> report.md
+          echo "![](./prediction_behavior.png)" >> report.md
           cml comment create report.md


### PR DESCRIPTION
Hey, I saw you post this bug when trying to make a .md file with an image.
https://github.com/orgs/community/discussions/57478

Also I remember seeing your username in Platzi's classes for https://platzi.com/cursos/ml-ops/
I was doing that recently and yesterday run into the same problem you had.
The solution is to update the node version (select from yaml).

I've made the following changes in the pull request:
- Added a set up for node version 16
- Added again your line for echo "![](./prediction_behavior.png)" >> report.md
I hope it will work for you, best of luck.